### PR TITLE
Register unidentified user on init and reset

### DIFF
--- a/Segment-Intercom/Classes/SEGIntercomIntegration.m
+++ b/Segment-Intercom/Classes/SEGIntercomIntegration.m
@@ -27,6 +27,9 @@
 
         [self.intercom setApiKey:mobileApiKey forAppId:appId];
         SEGLog(@"[self.intercom setApiKey:%@ forAppId:%@];", mobileApiKey, appId);
+
+        [self.intercom registerUnidentifiedUser];
+        SEGLog(@"[Intercom registerUnidentifiedUser];");
     }
 
 
@@ -130,6 +133,9 @@
 {
     [self.intercom reset];
     SEGLog(@" [Intercom reset];");
+
+    [self.intercom registerUnidentifiedUser];
+    SEGLog(@"[Intercom registerUnidentifiedUser];");
 }
 
 #pragma mark - Utils


### PR DESCRIPTION
Trying to open an intercom chat (`[Intercom presentMessageComposer];`) without being logged in leads to an error since Intercom ALWAYS requires the user to be identified. 
Luckily intercom offers the `registerUnidentifiedUser` method.

Looking at the current Intercom integration this method is also included:
https://github.com/segment-integrations/analytics-ios-integration-intercom/blob/master/Segment-Intercom/Classes/SEGIntercomIntegration.m#L52

Unfortunately this method never seems to be called since an identify call with the segment SDK ALWAYS requires a user. So the `else if (payload.anonymousId)` where `registerUnidentifiedUser` would be called is never reached.

This pull requests changes this behavior and ALWAYS ensures that intercom has either an unregistered user (set within init and reset method) or a registered one (set in identify).
This way the intercom chat can still be shown even though the user has not identified before.

NOTE:
I applied the same changes to the android integration: https://github.com/segment-integrations/analytics-android-integration-intercom/pull/16