### PR TITLE
Make booleans consistent in SEGIntercomIntegration

### DIFF
--- a/Segment-Intercom/Classes/SEGIntercomIntegration.m
+++ b/Segment-Intercom/Classes/SEGIntercomIntegration.m
@@ -77,7 +77,7 @@
 
     NSMutableDictionary *output = [NSMutableDictionary dictionaryWithCapacity:payload.properties.count];
     NSMutableDictionary *price = [NSMutableDictionary dictionaryWithCapacity:0];
-    __block BOOL isAmountSet = false;
+    __block BOOL isAmountSet = NO;
 
     [payload.properties enumerateKeysAndObjectsUsingBlock:^(id key, id data, BOOL *stop) {
         [output setObject:data forKey:key];
@@ -88,7 +88,7 @@
             [price setObject:finalAmount forKey:@"amount"];
 
             [output removeObjectForKey:key];
-            isAmountSet = @YES;
+            isAmountSet = YES;
         }
 
         if ([key isEqual:@"currency"]) {


### PR DESCRIPTION
This PR changes the boolean values assigned to `isAmountSet` to be consistent with standard ObjC boolean types.  Here the use of `false` has been changed to `NO` & the use of `@YES`, which was flagging a compiler warning since Xcode 10 at least, has been changed to `YES`.