### PR TITLE
Carthage support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,9 +26,12 @@ Carthage
 # We recommend against adding the Pods directory to your .gitignore. However
 # you should judge for yourself, the pros and cons are mentioned at:
 # http://guides.cocoapods.org/using/using-cocoapods.html#should-i-ignore-the-pods-directory-in-source-control
-# 
+#
 # Note: if you ignore the Pods directory, make sure to uncomment
 # `pod install` in .travis.yml
 #
+Carthage/
 Pods/
 .clang-format
+/Segment-Intercom.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+/Segment-Intercom.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist

--- a/Cartfile
+++ b/Cartfile
@@ -1,0 +1,2 @@
+github "segmentio/analytics-ios"
+github "intercom/intercom-ios"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,0 +1,2 @@
+github "intercom/intercom-ios" "7.1.1"
+github "segmentio/analytics-ios" "4.0.4"

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ XC_ARGS := -scheme $(PROJECT)-Example -workspace Example/$(PROJECT).xcworkspace 
 install: Example/Podfile $(PROJECT).podspec
 	pod repo update
 	pod install --project-directory=Example
+	carthage bootstrap --platform ios --use-ssh
 
 lint:
 	pod lib lint --use-libraries --allow-warnings

--- a/Segment-Intercom.xcodeproj/project.pbxproj
+++ b/Segment-Intercom.xcodeproj/project.pbxproj
@@ -1,0 +1,394 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		F4418FAB24D2720F002FC779 /* SEGIntercomIntegration.m in Sources */ = {isa = PBXBuildFile; fileRef = F4418FA124D2720F002FC779 /* SEGIntercomIntegration.m */; };
+		F4418FAD24D2720F002FC779 /* SEGIntercomIntegrationFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = F4418FA324D2720F002FC779 /* SEGIntercomIntegrationFactory.m */; };
+		F4418FAE24D2720F002FC779 /* SEGIntercomIntegration.h in Headers */ = {isa = PBXBuildFile; fileRef = F4418FA424D2720F002FC779 /* SEGIntercomIntegration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F4418FAF24D2720F002FC779 /* SEGIntercomIntegrationFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = F4418FA524D2720F002FC779 /* SEGIntercomIntegrationFactory.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F4418FB024D2720F002FC779 /* Segment_Intercom.h in Headers */ = {isa = PBXBuildFile; fileRef = F4418FA724D2720F002FC779 /* Segment_Intercom.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F4418FB624D2729B002FC779 /* Intercom.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4418FB424D2729B002FC779 /* Intercom.framework */; };
+		F4418FB724D2729B002FC779 /* Analytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4418FB524D2729B002FC779 /* Analytics.framework */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		F4418F9424D271B6002FC779 /* Segment_Intercom.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Segment_Intercom.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F4418FA124D2720F002FC779 /* SEGIntercomIntegration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SEGIntercomIntegration.m; sourceTree = "<group>"; };
+		F4418FA224D2720F002FC779 /* .gitkeep */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = .gitkeep; sourceTree = "<group>"; };
+		F4418FA324D2720F002FC779 /* SEGIntercomIntegrationFactory.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SEGIntercomIntegrationFactory.m; sourceTree = "<group>"; };
+		F4418FA424D2720F002FC779 /* SEGIntercomIntegration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SEGIntercomIntegration.h; sourceTree = "<group>"; };
+		F4418FA524D2720F002FC779 /* SEGIntercomIntegrationFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SEGIntercomIntegrationFactory.h; sourceTree = "<group>"; };
+		F4418FA724D2720F002FC779 /* Segment_Intercom.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Segment_Intercom.h; sourceTree = "<group>"; };
+		F4418FA824D2720F002FC779 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		F4418FB424D2729B002FC779 /* Intercom.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Intercom.framework; path = Carthage/Build/iOS/Intercom.framework; sourceTree = SOURCE_ROOT; };
+		F4418FB524D2729B002FC779 /* Analytics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Analytics.framework; path = Carthage/Build/iOS/Analytics.framework; sourceTree = SOURCE_ROOT; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		F4418F9124D271B6002FC779 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F4418FB624D2729B002FC779 /* Intercom.framework in Frameworks */,
+				F4418FB724D2729B002FC779 /* Analytics.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		F4418F8A24D271B6002FC779 = {
+			isa = PBXGroup;
+			children = (
+				F4418FB324D27289002FC779 /* Frameworks */,
+				F4418F9F24D2720F002FC779 /* Segment-Intercom */,
+				F4418F9524D271B6002FC779 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		F4418F9524D271B6002FC779 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				F4418F9424D271B6002FC779 /* Segment_Intercom.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		F4418F9F24D2720F002FC779 /* Segment-Intercom */ = {
+			isa = PBXGroup;
+			children = (
+				F4418FA024D2720F002FC779 /* Classes */,
+				F4418FA624D2720F002FC779 /* Resources */,
+			);
+			path = "Segment-Intercom";
+			sourceTree = "<group>";
+		};
+		F4418FA024D2720F002FC779 /* Classes */ = {
+			isa = PBXGroup;
+			children = (
+				F4418FA124D2720F002FC779 /* SEGIntercomIntegration.m */,
+				F4418FA224D2720F002FC779 /* .gitkeep */,
+				F4418FA324D2720F002FC779 /* SEGIntercomIntegrationFactory.m */,
+				F4418FA424D2720F002FC779 /* SEGIntercomIntegration.h */,
+				F4418FA524D2720F002FC779 /* SEGIntercomIntegrationFactory.h */,
+			);
+			path = Classes;
+			sourceTree = "<group>";
+		};
+		F4418FA624D2720F002FC779 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				F4418FA724D2720F002FC779 /* Segment_Intercom.h */,
+				F4418FA824D2720F002FC779 /* Info.plist */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		F4418FB324D27289002FC779 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				F4418FB524D2729B002FC779 /* Analytics.framework */,
+				F4418FB424D2729B002FC779 /* Intercom.framework */,
+			);
+			path = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		F4418F8F24D271B6002FC779 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F4418FB024D2720F002FC779 /* Segment_Intercom.h in Headers */,
+				F4418FAE24D2720F002FC779 /* SEGIntercomIntegration.h in Headers */,
+				F4418FAF24D2720F002FC779 /* SEGIntercomIntegrationFactory.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		F4418F9324D271B6002FC779 /* Segment-Intercom */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F4418F9C24D271B6002FC779 /* Build configuration list for PBXNativeTarget "Segment-Intercom" */;
+			buildPhases = (
+				F4418F8F24D271B6002FC779 /* Headers */,
+				F4418F9024D271B6002FC779 /* Sources */,
+				F4418F9124D271B6002FC779 /* Frameworks */,
+				F4418F9224D271B6002FC779 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Segment-Intercom";
+			productName = "Segment-Intercoms";
+			productReference = F4418F9424D271B6002FC779 /* Segment_Intercom.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		F4418F8B24D271B6002FC779 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1160;
+				ORGANIZATIONNAME = Mapbox;
+				TargetAttributes = {
+					F4418F9324D271B6002FC779 = {
+						CreatedOnToolsVersion = 11.6;
+					};
+				};
+			};
+			buildConfigurationList = F4418F8E24D271B6002FC779 /* Build configuration list for PBXProject "Segment-Intercom" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = F4418F8A24D271B6002FC779;
+			productRefGroup = F4418F9524D271B6002FC779 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				F4418F9324D271B6002FC779 /* Segment-Intercom */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		F4418F9224D271B6002FC779 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		F4418F9024D271B6002FC779 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F4418FAD24D2720F002FC779 /* SEGIntercomIntegrationFactory.m in Sources */,
+				F4418FAB24D2720F002FC779 /* SEGIntercomIntegration.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		F4418F9A24D271B6002FC779 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		F4418F9B24D271B6002FC779 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		F4418F9D24D271B6002FC779 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Manual;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = "$(SRCROOT)/Segment-Intercom/Resources/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.dane.miluski.Segment-Intercom";
+				PRODUCT_NAME = Segment_Intercom;
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		F4418F9E24D271B6002FC779 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Manual;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = "$(SRCROOT)/Segment-Intercom/Resources/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.dane.miluski.Segment-Intercom";
+				PRODUCT_NAME = Segment_Intercom;
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		F4418F8E24D271B6002FC779 /* Build configuration list for PBXProject "Segment-Intercom" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F4418F9A24D271B6002FC779 /* Debug */,
+				F4418F9B24D271B6002FC779 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F4418F9C24D271B6002FC779 /* Build configuration list for PBXNativeTarget "Segment-Intercom" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F4418F9D24D271B6002FC779 /* Debug */,
+				F4418F9E24D271B6002FC779 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = F4418F8B24D271B6002FC779 /* Project object */;
+}

--- a/Segment-Intercom.xcodeproj/xcshareddata/xcschemes/Segment-Intercom.xcscheme
+++ b/Segment-Intercom.xcodeproj/xcshareddata/xcschemes/Segment-Intercom.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1160"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F4418F9324D271B6002FC779"
+               BuildableName = "Segment_Intercom.framework"
+               BlueprintName = "Segment-Intercom"
+               ReferencedContainer = "container:Segment-Intercom.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F4418F9324D271B6002FC779"
+            BuildableName = "Segment_Intercom.framework"
+            BlueprintName = "Segment-Intercom"
+            ReferencedContainer = "container:Segment-Intercom.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Segment-Intercom/Resources/Info.plist
+++ b/Segment-Intercom/Resources/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/Segment-Intercom/Resources/Segment_Intercom.h
+++ b/Segment-Intercom/Resources/Segment_Intercom.h
@@ -1,0 +1,19 @@
+//
+//  Segment_Intercom.h
+//  Segment-Intercom
+//
+//  Created by Dane Miluski on 7/29/20.
+//  Copyright © 2020 Mapbox. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for Segment_Intercom.
+FOUNDATION_EXPORT double Segment_IntercomVersionNumber;
+
+//! Project version string for Segment_Intercoms.
+FOUNDATION_EXPORT const unsigned char Segment_IntercomVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <Segment_Intercom/PublicHeader.h>
+#import <Segment_Intercom/SEGIntercomIntegration.h>
+#import <Segment_Intercom/SEGIntercomIntegrationFactory.h>


### PR DESCRIPTION
Problem:
Existing Intercom integration does not support Carthage

Approach:
Including packaging project -> framework which can be consumed by developers

There's likely a better approach given guidelines, but this allowed be to build and link with firebase + integrations with carthage via 

Cartfile:
```
github "dmiluski/analytics-ios-integration-firebase" "carthage-support"
```

`carthage bootstrap --platform ios --use-ssh --cache-builds`


Changes:
+ Include Cartfile
+ Include Packaging Project
- Ignore unnecessary files
+ Expose headers
+ Share scheme