### PR TITLE
Add type insurance for userId assignment of Bugsnag

### DIFF
--- a/Segment-Intercom/Classes/SEGIntercomIntegration.m
+++ b/Segment-Intercom/Classes/SEGIntercomIntegration.m
@@ -155,7 +155,7 @@
     }
 
     if (traits[@"user_id"]) {
-        userAttributes.userId = traits[@"user_id"];
+        userAttributes.userId = [NSString stringWithFormat:@"%@", traits[@"user_id"]];
         [customAttributes removeObjectForKey:@"user_id"];
     }
 


### PR DESCRIPTION
Because it's logging internal error when it's passed without initializing NSString and all characters are numbers